### PR TITLE
fix(winc): extract full DHCP configuration including subnet, gateway, and DNS

### DIFF
--- a/driver/winc/wdrv_winc.c
+++ b/driver/winc/wdrv_winc.c
@@ -866,7 +866,7 @@ static void _WDRV_WINC_WifiCallback(uint8_t msgType, const void *const pMsgConte
         /* The IP address of the connection has been updated due to DHCP. */
         case M2M_WIFI_REQ_DHCP_CONF:
         {
-            const uint8_t *const pIP = (const uint8_t *const)pMsgContent;
+            const tstrM2MIPConfig *const pIPConfig = (const tstrM2MIPConfig *const)pMsgContent;
 
             if (false == pDcpt->pCtrl->isAP)
             {
@@ -874,10 +874,11 @@ static void _WDRV_WINC_WifiCallback(uint8_t msgType, const void *const pMsgConte
                 pDcpt->pCtrl->haveIPAddress = true;
             }
 
-            pDcpt->pCtrl->ipAddress = ( (uint32_t)pIP[3] << 24) |
-                                      ( (uint32_t)pIP[2] << 16) |
-                                      ( (uint32_t)pIP[1] << 8 ) |
-                                      ( (uint32_t)pIP[0]);
+            /* Extract complete network configuration from DHCP response */
+            pDcpt->pCtrl->ipAddress = pIPConfig->u32StaticIP;
+            pDcpt->pCtrl->netMask = pIPConfig->u32SubnetMask;
+            pDcpt->pCtrl->gatewayAddress = pIPConfig->u32Gateway;
+            pDcpt->pCtrl->dnsServerAddress = pIPConfig->u32DNS;
 
             if (NULL != pDcpt->pCtrl->pfDHCPAddressEventCB)
             {


### PR DESCRIPTION
## Description
This PR fixes the DHCP callback handler to properly extract all network configuration fields from the DHCP response, not just the IP address.

## Problem
The WINC driver's DHCP callback handler (`M2M_WIFI_REQ_DHCP_CONF`) incorrectly casts the message content to `uint8_t*` and only extracts 4 bytes (IP address), even though the WINC firmware provides complete network configuration in the `tstrM2MIPConfig` structure.

## Solution
- Properly cast the message content to `tstrM2MIPConfig*`
- Extract all network configuration fields:
  - IP address (u32StaticIP)
  - Subnet mask (u32SubnetMask)  
  - Gateway (u32Gateway)
  - DNS server (u32DNS)

## Technical Details
The control structure already has fields for these values (netMask, gatewayAddress, dnsServerAddress) but they were never populated from the DHCP response. This change ensures applications can access complete network configuration obtained via DHCP.

## Testing
- Connect to a network using DHCP
- Verify that subnet mask, gateway, and DNS are correctly extracted
- Compare values with those assigned by the DHCP server

Fixes #4

## References
- [Microchip Knowledge Base Article](https://microchip.my.site.com/s/article/How-to-retrieve-IP-Gateway-Subnet-and-DNS-Information-when-the-ATWINC1500-is-connected-to-a-Wi-Fi-network)
- Issue #4